### PR TITLE
Fix gemspec executables

### DIFF
--- a/lita-tweet.gemspec
+++ b/lita-tweet.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.metadata      = { "lita_plugin_type" => "handler" }
 
   spec.files         = `git ls-files`.split($/)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
lita-tweet was overwriting the executables with all of the files inside of `/bin` (ie. guard, rake, rspec). This blog post http://bundler.io/blog/2015/03/20/moving-bins-to-exe.html goes into detail about exactly why that happens, and suggests this change as a recommended fix. I tested it, and it does in fact fix the issue.
